### PR TITLE
fix: scaffold script doesn't work for packages with dots in the name

### DIFF
--- a/scripts/scaffold-codemod.js
+++ b/scripts/scaffold-codemod.js
@@ -12,7 +12,7 @@ import jscodeshift from 'jscodeshift';
 const name = process.argv[2];
 
 /** @param {string} s */
-const camelize = (s) => s.replace(/-./g, (x) => x[1].toUpperCase());
+const camelize = (s) => s.replace(/[-\.]./g, (x) => x[1].toUpperCase());
 
 fs.mkdirSync(`./test/fixtures/${name}/case-1`, { recursive: true });
 fs.writeFileSync(
@@ -38,7 +38,7 @@ fs.writeFileSync(
  */
 
 /**
- * @param {CodemodOptions} [options] 
+ * @param {CodemodOptions} [options]
  * @returns {Codemod}
  */
 export default function(options) {


### PR DESCRIPTION
When I used the scaffold script to generate files for the `array.prototype.map` package, it added this line to `index.js`
```js
import array.prototype.map from './array.prototype.map/index.js';
```
This PR fixes this. Now the generated code is valid js.
```js
import arrayPrototypeMap from './array.prototype.map/index.js';
```