### PR TITLE
Add codemod to replace `object-keys`

### DIFF
--- a/codemods/index.js
+++ b/codemods/index.js
@@ -18,6 +18,8 @@ import arrayPrototypeFilter from './array.prototype.filter/index.js';
 
 import arrayIncludes from './array-includes/index.js';
 
+import objectKeys from './object-keys/index.js';
+
 export const codemods = {
 	'is-whitespace': isWhitespace,
 	'is-array-buffer': isArrayBuffer,
@@ -29,4 +31,5 @@ export const codemods = {
 	'array.prototype.map': arrayPrototypeMap,
 	'array.prototype.filter': arrayPrototypeFilter,
 	'array-includes': arrayIncludes,
+	'object-keys': objectKeys,
 };

--- a/codemods/object-keys/index.js
+++ b/codemods/object-keys/index.js
@@ -1,6 +1,5 @@
 import jscodeshift from "jscodeshift";
 import { removeImport } from "../shared.js";
-import { log } from "console";
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod

--- a/codemods/object-keys/index.js
+++ b/codemods/object-keys/index.js
@@ -1,5 +1,6 @@
 import jscodeshift from "jscodeshift";
 import { removeImport } from "../shared.js";
+import { log } from "console";
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -17,7 +18,53 @@ export default function (options) {
 			const j = jscodeshift;
 			const root = j(file.source);
 
-			const { identifier } = removeImport("object-keys", root, j);
+			let { identifier } = removeImport("object-keys", root, j);
+
+			// Replace `$identifier(obj)` with `Object.keys(obj)`
+			root
+				.find(j.CallExpression, {
+					callee: {
+						name: identifier,
+					},
+				})
+				.replaceWith(({ node }) => {
+					return j.callExpression(
+						j.memberExpression(j.identifier("Object"), j.identifier("keys")),
+						node.arguments
+					);
+				});
+
+			// Remove recommended usage of `var keys = Object.keys || require("object-keys")`
+			const logicalExpressionRequire = root.find(j.VariableDeclarator, {
+				init: {
+					type: "LogicalExpression",
+					left: {
+						object: {
+							name: "Object",
+						},
+						property: {
+							name: "keys",
+						},
+					},
+					right: {
+						callee: {
+							name: "require",
+						},
+						arguments: [
+							{
+								value: "object-keys",
+							},
+						],
+					},
+				},
+			});
+
+			identifier =
+				logicalExpressionRequire.paths().length > 0
+					? logicalExpressionRequire.get().node.id.name
+					: null;
+
+			logicalExpressionRequire.remove();
 
 			// Replace `$identifier(obj)` with `Object.keys(obj)`
 			root

--- a/codemods/object-keys/index.js
+++ b/codemods/object-keys/index.js
@@ -1,0 +1,39 @@
+import jscodeshift from "jscodeshift";
+import { removeImport } from "../shared.js";
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: "object-keys",
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const { identifier } = removeImport("object-keys", root, j);
+
+			// Replace `$identifier(obj)` with `Object.keys(obj)`
+			root
+				.find(j.CallExpression, {
+					callee: {
+						name: identifier,
+					},
+				})
+				.replaceWith(({ node }) => {
+					return j.callExpression(
+						j.memberExpression(j.identifier("Object"), j.identifier("keys")),
+						node.arguments
+					);
+				});
+
+			return root.toSource(options);
+		},
+	};
+}

--- a/codemods/shared.js
+++ b/codemods/shared.js
@@ -1,29 +1,45 @@
 /**
+ * type definition for return type object
+ * @typedef {Object} RemoveImport
+ * @property {string} identifier - the name of the module as it was imported or required. for example, `keys` in `import keys from 'object-keys'`
+ */
+
+/**
  * @param {string} name - package name to remove import/require calls for
- * @param {any} root - package name to remove import/require calls for
- * @param {any} j - jscodeshift instance
+ * @param {import("jscodeshift").Collection} root - package name to remove import/require calls for
+ * @param {import("jscodeshift").JSCodeshift} j - jscodeshift instance
+ * @returns {RemoveImport}
  */
 export function removeImport(name, root, j) {
-	// Find the import or require statement for 'is-boolean-object'
-	const importDeclaration = root.find(j.ImportDeclaration, {
-		source: {
-			value: name,
-		},
-	});
+  // Find the import or require statement for 'is-boolean-object'
+  const importDeclaration = root.find(j.ImportDeclaration, {
+    source: {
+      value: name,
+    },
+  });
 
-	const requireDeclaration = root.find(j.VariableDeclarator, {
-		init: {
-			callee: {
-				name: 'require',
-			},
-			arguments: [
-				{
-					value: name,
-				},
-			],
-		},
-	});
+  const requireDeclaration = root.find(j.VariableDeclarator, {
+    init: {
+      callee: {
+        name: "require",
+      },
+      arguments: [
+        {
+          value: name,
+        },
+      ],
+    },
+  });
 
-	importDeclaration.remove();
-	requireDeclaration.remove();
+  // Return the identifier name, e.g. 'fn' in `import { fn } from 'is-boolean-object'`
+  // or `var fn = require('is-boolean-object')`
+  const identifier =
+    importDeclaration.paths().length > 0
+      ? importDeclaration.get().node.specifiers[0].local.name
+      : requireDeclaration.find(j.Identifier).get().node.name;
+
+  importDeclaration.remove();
+  requireDeclaration.remove();
+
+  return { identifier };
 }

--- a/codemods/shared.js
+++ b/codemods/shared.js
@@ -36,7 +36,9 @@ export function removeImport(name, root, j) {
   const identifier =
     importDeclaration.paths().length > 0
       ? importDeclaration.get().node.specifiers[0].local.name
-      : requireDeclaration.find(j.Identifier).get().node.name;
+      : requireDeclaration.paths().length > 0
+      ? requireDeclaration.find(j.Identifier).get().node.name
+      : null;
 
   importDeclaration.remove();
   requireDeclaration.remove();

--- a/test/fixtures/object-keys/case-1/after.js
+++ b/test/fixtures/object-keys/case-1/after.js
@@ -1,0 +1,7 @@
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+Object.keys(obj);

--- a/test/fixtures/object-keys/case-1/before.js
+++ b/test/fixtures/object-keys/case-1/before.js
@@ -1,0 +1,8 @@
+var keys = require("object-keys");
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+keys(obj);

--- a/test/fixtures/object-keys/case-1/result.js
+++ b/test/fixtures/object-keys/case-1/result.js
@@ -1,0 +1,7 @@
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+Object.keys(obj);

--- a/test/fixtures/object-keys/case-2/after.js
+++ b/test/fixtures/object-keys/case-2/after.js
@@ -1,0 +1,7 @@
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+Object.keys(obj);

--- a/test/fixtures/object-keys/case-2/before.js
+++ b/test/fixtures/object-keys/case-2/before.js
@@ -1,0 +1,8 @@
+import keys from "object-keys";
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+keys(obj);

--- a/test/fixtures/object-keys/case-2/result.js
+++ b/test/fixtures/object-keys/case-2/result.js
@@ -1,0 +1,7 @@
+var obj = {
+  a: true,
+  b: true,
+  c: true,
+};
+
+Object.keys(obj);

--- a/test/fixtures/object-keys/case-3/after.js
+++ b/test/fixtures/object-keys/case-3/after.js
@@ -1,0 +1,1 @@
+console.log(Object.keys({ a: 1, b: "2", c: true }));

--- a/test/fixtures/object-keys/case-3/before.js
+++ b/test/fixtures/object-keys/case-3/before.js
@@ -1,0 +1,3 @@
+import banana from "object-keys";
+
+console.log(banana({ a: 1, b: "2", c: true }));

--- a/test/fixtures/object-keys/case-3/result.js
+++ b/test/fixtures/object-keys/case-3/result.js
@@ -1,0 +1,1 @@
+console.log(Object.keys({ a: 1, b: "2", c: true }));

--- a/test/fixtures/object-keys/case-4/after.js
+++ b/test/fixtures/object-keys/case-4/after.js
@@ -1,0 +1,1 @@
+console.log(Object.keys({ a: true }));

--- a/test/fixtures/object-keys/case-4/before.js
+++ b/test/fixtures/object-keys/case-4/before.js
@@ -1,0 +1,3 @@
+var keys = Object.keys || require("object-keys");
+
+console.log(keys({ a: true }));

--- a/test/fixtures/object-keys/case-4/result.js
+++ b/test/fixtures/object-keys/case-4/result.js
@@ -1,0 +1,1 @@
+console.log(Object.keys({ a: true }));


### PR DESCRIPTION
This adds a codemod replacement for the [`object-keys` module](https://www.npmjs.com/package/object-keys). This is my first time writing a codemod, so let me know if there's anything I can do to improve this code.

I've also added some improvements to the codebase that I think will be generally useful:
- Returned the identifier name from `removeImport` so that it will work even if the import is renamed to something than what is conventional
- Added some types to `removeImport`