### PR TITLE
style: add trailling comma option

### DIFF
--- a/scripts/scaffold-codemod.js
+++ b/scripts/scaffold-codemod.js
@@ -71,4 +71,4 @@ root.find(j.ObjectExpression).forEach((path) => {
 	);
 });
 
-fs.writeFileSync('./codemods/index.js', root.toSource({ quote: 'single' }));
+fs.writeFileSync('./codemods/index.js', root.toSource({ quote: 'single', trailingComma: true }));


### PR DESCRIPTION
Adds trailling commas to generated `codemods/index.js` file. This should align the style with the Biome configuration where trailing commas are enabled by default.

I noticed this small issue when I was resolving conflicts and I had to manually add the comma.