### PR TITLE
Replace md5 package

### DIFF
--- a/codemods/index.js
+++ b/codemods/index.js
@@ -150,6 +150,8 @@ import leftPad from './left-pad/index.js';
 
 import padLeft from './pad-left/index.js';
 
+import md5 from './md5/index.js';
+
 export const codemods = {
 	'is-whitespace': isWhitespace,
 	'is-array-buffer': isArrayBuffer,
@@ -227,4 +229,5 @@ export const codemods = {
 	'error-cause': errorCause,
 	'left-pad': leftPad,
 	'pad-left': padLeft,
+	md5: md5,
 };

--- a/codemods/md5/index.js
+++ b/codemods/md5/index.js
@@ -1,0 +1,59 @@
+import jscodeshift from 'jscodeshift';
+import { replaceDefaultImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'md5',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const { identifier } = replaceDefaultImport(
+				'md5',
+				'crypto',
+				'crypto',
+				root,
+				j,
+			);
+
+			// Replace function calls
+			root
+				.find(j.CallExpression, {
+					callee: { name: identifier },
+				})
+				.forEach((path) => {
+					const newExpression = j.callExpression(
+						j.memberExpression(
+							j.callExpression(
+								j.memberExpression(
+									j.callExpression(
+										j.memberExpression(
+											j.identifier('crypto'),
+											j.identifier('createHash'),
+										),
+										[j.literal('md5')],
+									),
+									j.identifier('update'),
+								),
+								path.node.arguments,
+							),
+							j.identifier('digest'),
+						),
+						[j.literal('hex')],
+					);
+					j(path).replaceWith(newExpression);
+				});
+
+			return root.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/test/fixtures/md5/case-1/after.js
+++ b/test/fixtures/md5/case-1/after.js
@@ -1,0 +1,2 @@
+import crypto from 'crypto';
+console.log(crypto.createHash('md5').update('message').digest('hex'));

--- a/test/fixtures/md5/case-1/before.js
+++ b/test/fixtures/md5/case-1/before.js
@@ -1,0 +1,2 @@
+import md5 from 'md5';
+console.log(md5('message'));

--- a/test/fixtures/md5/case-1/result.js
+++ b/test/fixtures/md5/case-1/result.js
@@ -1,0 +1,2 @@
+import crypto from 'crypto';
+console.log(crypto.createHash('md5').update('message').digest('hex'));

--- a/test/fixtures/md5/case-2/after.js
+++ b/test/fixtures/md5/case-2/after.js
@@ -1,0 +1,6 @@
+import fs from 'fs';
+import crypto from 'crypto';
+
+fs.readFile('example.txt', function (err, buf) {
+    console.log(crypto.createHash('md5').update(buf).digest('hex'));
+});

--- a/test/fixtures/md5/case-2/before.js
+++ b/test/fixtures/md5/case-2/before.js
@@ -1,0 +1,6 @@
+import fs from 'fs';
+import md5 from 'md5';
+
+fs.readFile('example.txt', function (err, buf) {
+    console.log(md5(buf));
+});

--- a/test/fixtures/md5/case-2/result.js
+++ b/test/fixtures/md5/case-2/result.js
@@ -1,0 +1,6 @@
+import fs from 'fs';
+import crypto from 'crypto';
+
+fs.readFile('example.txt', function (err, buf) {
+    console.log(crypto.createHash('md5').update(buf).digest('hex'));
+});

--- a/test/fixtures/md5/case-3/after.js
+++ b/test/fixtures/md5/case-3/after.js
@@ -1,0 +1,2 @@
+var crypto = require('crypto');
+console.log(crypto.createHash('md5').update('message').digest('hex'));

--- a/test/fixtures/md5/case-3/before.js
+++ b/test/fixtures/md5/case-3/before.js
@@ -1,0 +1,2 @@
+var md5 = require('md5');
+console.log(md5('message'));

--- a/test/fixtures/md5/case-3/result.js
+++ b/test/fixtures/md5/case-3/result.js
@@ -1,0 +1,2 @@
+var crypto = require('crypto');
+console.log(crypto.createHash('md5').update('message').digest('hex'));

--- a/test/fixtures/md5/case-4/after.js
+++ b/test/fixtures/md5/case-4/after.js
@@ -1,0 +1,2 @@
+var crypto = require('crypto');
+console.log(crypto.createHash('md5').update('message').digest('hex'));

--- a/test/fixtures/md5/case-4/before.js
+++ b/test/fixtures/md5/case-4/before.js
@@ -1,0 +1,2 @@
+var myMD5 = require('md5');
+console.log(myMD5('message'));

--- a/test/fixtures/md5/case-4/result.js
+++ b/test/fixtures/md5/case-4/result.js
@@ -1,0 +1,2 @@
+var crypto = require('crypto');
+console.log(crypto.createHash('md5').update('message').digest('hex'));


### PR DESCRIPTION
Hi!

This PR replaces [md5](https://www.npmjs.com/package/md5) with the build-in `crypto` package. I'm using codemods and `jscodeshift` for the first time so I'd appreciate some feedback on the PR:
- It replaces `import md5 from 'md5'` successfully. What about `var md5 = require('md5');`? Do I need to handle this? Should this live in the same transformation file?
- What does `dirtyFlag` do?
- Should I transform to single or double quotes?
- Should I worry that this only works for node and not front end projects?

The replacement is based on [this](https://stackoverflow.com/questions/1655769/fastest-md5-implementation-in-javascript) SO answer. I also tested the generated code locally and it looks fine to me:
```bash
# test a string
~/Development/node-playground> node md5-package.js
78e731027d8fd50ed642340b7c9a63b3
~/Development/node-playground> node md5-crypto.js
78e731027d8fd50ed642340b7c9a63b3

# test a buffer
~/Development/node-playground> node md5-buffer-package.js
cf778431631ef17d1e8bb1b84e13d25a
~/Development/node-playground> node md5-buffer-crypto.js
cf778431631ef17d1e8bb1b84e13d25a
```

