### PR TITLE
Add codemod for `error-cause` package

### DIFF
--- a/codemods/error-cause/index.js
+++ b/codemods/error-cause/index.js
@@ -1,0 +1,25 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'error-cause',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			removeImport('error-cause/auto', root, j);
+
+			return root.toSource(options);
+		},
+	};
+}

--- a/codemods/index.js
+++ b/codemods/index.js
@@ -144,6 +144,8 @@ import indexOf from './index-of/index.js';
 
 import lastIndexOf from './last-index-of/index.js';
 
+import errorCause from './error-cause/index.js';
+
 export const codemods = {
 	'is-whitespace': isWhitespace,
 	'is-array-buffer': isArrayBuffer,
@@ -218,4 +220,5 @@ export const codemods = {
 	'array-map': arrayMap,
 	'index-of': indexOf,
 	'last-index-of': lastIndexOf,
+	'error-cause': errorCause,
 };

--- a/codemods/shared.js
+++ b/codemods/shared.js
@@ -46,6 +46,20 @@ export function removeImport(name, root, j) {
 		},
 	});
 
+	// Side effect requires statements like `require("error-cause/auto");`
+	const sideEffectRequireExpression = root.find(j.ExpressionStatement, {
+		expression: {
+			callee: {
+				name: 'require',
+			},
+			arguments: [
+				{
+					value: name,
+				},
+			],
+		},
+	});
+
 	// Return the identifier name, e.g. 'fn' in `import { fn } from 'is-boolean-object'`
 	// or `var fn = require('is-boolean-object')`
 	const identifier =
@@ -60,6 +74,7 @@ export function removeImport(name, root, j) {
 	importDeclaration.remove();
 	requireDeclaration.remove();
 	requireAssignment.remove();
+	sideEffectRequireExpression.remove();
 
 	return { identifier };
 }

--- a/test/fixtures/error-cause/case-1/after.js
+++ b/test/fixtures/error-cause/case-1/after.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+
+try {
+  x();
+} catch (e) {
+  const actual = new Error("a better message!", { cause: e });
+  assert(actual instanceof Error);
+  assert(actual.cause === e);
+}

--- a/test/fixtures/error-cause/case-1/before.js
+++ b/test/fixtures/error-cause/case-1/before.js
@@ -1,0 +1,11 @@
+const assert = require("assert");
+
+require("error-cause/auto");
+
+try {
+  x();
+} catch (e) {
+  const actual = new Error("a better message!", { cause: e });
+  assert(actual instanceof Error);
+  assert(actual.cause === e);
+}

--- a/test/fixtures/error-cause/case-1/result.js
+++ b/test/fixtures/error-cause/case-1/result.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+
+try {
+  x();
+} catch (e) {
+  const actual = new Error("a better message!", { cause: e });
+  assert(actual instanceof Error);
+  assert(actual.cause === e);
+}


### PR DESCRIPTION
Codemod for [`error-cause`](https://www.npmjs.com/package/error-cause), a package that polyfills the native [`Error.cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) property, which has been available in all modern browsers and Node since ~2021.

It's not a particularly popular package, but just wanted to start with a simple codemod for my first contribution. Turned out to be worthwhile though because there wasn't an existing utility for removing side-effect `require`s, which is how `error-cause` injects its polyfill, so I added one.

Looking at the code, I think it's possible to polyfill individual error types, e.g. [`ReferenceError`](https://github.com/es-shims/error-cause/blob/792d2c6993c6bb6c47da52f3de2982c8cf98481c/ReferenceError/auto.js). Given that, it _could_ be worth removing imports for `error-cuase/ReferenceError/auto` (and all the other error types), but my guess is that most usage is just via `error-cause/auto`. You can also import and call the polyfill function manually, but again this is probably not commonly used.