### PR TITLE
Add codemod for `array-buffer-byte-length` package

### DIFF
--- a/codemods/array-buffer-byte-length/index.js
+++ b/codemods/array-buffer-byte-length/index.js
@@ -1,0 +1,48 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'array-buffer-byte-length',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const { identifier } = removeImport('array-buffer-byte-length', root, j);
+
+			let dirtyFlag = false;
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const [bufferArg] = path.node.arguments;
+					if (
+						j.Identifier.check(bufferArg) ||
+						(j.NewExpression.check(bufferArg) &&
+							bufferArg.callee.type === 'Identifier' &&
+							bufferArg.callee.name === 'ArrayBuffer')
+					) {
+						path.replace(
+							j.memberExpression(bufferArg, j.identifier('byteLength')),
+						);
+						dirtyFlag = true;
+					}
+				});
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/codemods/index.js
+++ b/codemods/index.js
@@ -144,6 +144,8 @@ import indexOf from './index-of/index.js';
 
 import lastIndexOf from './last-index-of/index.js';
 
+import arrayBufferByteLength from './array-buffer-byte-length/index.js';
+
 export const codemods = {
 	'is-whitespace': isWhitespace,
 	'is-array-buffer': isArrayBuffer,
@@ -218,4 +220,5 @@ export const codemods = {
 	'array-map': arrayMap,
 	'index-of': indexOf,
 	'last-index-of': lastIndexOf,
+	'array-buffer-byte-length': arrayBufferByteLength,
 };

--- a/codemods/index.js
+++ b/codemods/index.js
@@ -232,5 +232,5 @@ export const codemods = {
 	'left-pad': leftPad,
 	'pad-left': padLeft,
 	md5: md5,
-  'array-buffer-byte-length': arrayBufferByteLength,
+	'array-buffer-byte-length': arrayBufferByteLength,
 };

--- a/test/fixtures/array-buffer-byte-length/case-1/after.js
+++ b/test/fixtures/array-buffer-byte-length/case-1/after.js
@@ -1,0 +1,15 @@
+const assert = require("assert");
+
+assert.equal(
+  new ArrayBuffer(0).byteLength,
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);
+
+const myArrayBuffer = new ArrayBuffer(0);
+
+assert.equal(
+  myArrayBuffer.byteLength,
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);

--- a/test/fixtures/array-buffer-byte-length/case-1/before.js
+++ b/test/fixtures/array-buffer-byte-length/case-1/before.js
@@ -1,0 +1,16 @@
+const assert = require("assert");
+const byteLength = require("array-buffer-byte-length");
+
+assert.equal(
+  byteLength(new ArrayBuffer(0)),
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);
+
+const myArrayBuffer = new ArrayBuffer(0);
+
+assert.equal(
+  byteLength(myArrayBuffer),
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);

--- a/test/fixtures/array-buffer-byte-length/case-1/result.js
+++ b/test/fixtures/array-buffer-byte-length/case-1/result.js
@@ -1,0 +1,15 @@
+const assert = require("assert");
+
+assert.equal(
+  new ArrayBuffer(0).byteLength,
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);
+
+const myArrayBuffer = new ArrayBuffer(0);
+
+assert.equal(
+  myArrayBuffer.byteLength,
+  0,
+  "ArrayBuffer of byteLength 0, yields 0",
+);


### PR DESCRIPTION
Codemod for [`array-buffer-byte-length`](https://www.npmjs.com/package/array-buffer-byte-length).

~I thought about abstracting some of the `ArrayBuffer` stuff into a shared util, but I think there's [only one other](https://github.com/es-tooling/module-replacements/blob/81e7dc647a208ed7e438b6e792a4150c8e0fff14/manifests/native.json#L251-L266) `ArrayBuffer` shim that needs a codemod, `arraybuffer.prototype.slice`, so I don't think it's worth it.~

**EDIT**: Actually, I think it could be worth adding utils like `transformInstanceMethod` and `transformInstanceProperty`. Would be useful for both `ArrayBuffer` and `TypedArray` codemods. I'll contribute them separately if they turn out to be useful.

I'll follow up with the `slice` codemod in a bit.