### PR TITLE
fix: wrong substitution in `array.prototype.entries`

### DIFF
--- a/codemods/array.prototype.entries/index.js
+++ b/codemods/array.prototype.entries/index.js
@@ -36,7 +36,7 @@ export default function (options) {
 							// Replace the call expression with a method call on the argument
 							j(path).replaceWith(
 								j.callExpression(
-									j.memberExpression(arg, j.identifier(identifier)),
+									j.memberExpression(arg, j.identifier('entries')),
 									[],
 								),
 							);

--- a/test/fixtures/array.prototype.entries/case-2/after.js
+++ b/test/fixtures/array.prototype.entries/case-2/after.js
@@ -1,0 +1,3 @@
+const foo = [1,2,3];
+[1, 2, 3].entries();
+foo.entries();

--- a/test/fixtures/array.prototype.entries/case-2/before.js
+++ b/test/fixtures/array.prototype.entries/case-2/before.js
@@ -1,0 +1,5 @@
+var banana = require('array.prototype.entries');
+
+const foo = [1,2,3];
+banana([1, 2, 3]);
+banana(foo);

--- a/test/fixtures/array.prototype.entries/case-2/result.js
+++ b/test/fixtures/array.prototype.entries/case-2/result.js
@@ -1,0 +1,3 @@
+const foo = [1,2,3];
+[1, 2, 3].entries();
+foo.entries();


### PR DESCRIPTION
This PR fixes a bug in the `array.prototype.entries` codemod that attempts to substitute the `const entries = require('array.prototype.entries')` import with `[].entries()`. It incorrectly derives the name of the native `entries` method in the `Array` prototype from the name of the import identifier. Therefore if I import:

```js
const entries = require('array.prototype.entries')
```

My code becomes:

```js
[].arrayEntries()
```

This PR also adds a fixture to cover the non-standard import name case.