### PR TITLE
fix: make `is-builtin-module` also support CJS + work with non-standard names

### DIFF
--- a/test/fixtures/is-builtin-module/case-2/after.js
+++ b/test/fixtures/is-builtin-module/case-2/after.js
@@ -1,0 +1,13 @@
+import { isBuiltin } from "node:module";
+
+isBuiltin('fs');
+//=> true
+
+isBuiltin('fs/promises');
+//=> true
+
+isBuiltin('node:fs/promises');
+//=> true
+
+isBuiltin('unicorn');
+//=> false

--- a/test/fixtures/is-builtin-module/case-2/before.js
+++ b/test/fixtures/is-builtin-module/case-2/before.js
@@ -1,0 +1,13 @@
+import banana from 'is-builtin-module';
+
+banana('fs');
+//=> true
+
+banana('fs/promises');
+//=> true
+
+banana('node:fs/promises');
+//=> true
+
+banana('unicorn');
+//=> false

--- a/test/fixtures/is-builtin-module/case-2/result.js
+++ b/test/fixtures/is-builtin-module/case-2/result.js
@@ -1,0 +1,13 @@
+import { isBuiltin } from "node:module";
+
+isBuiltin('fs');
+//=> true
+
+isBuiltin('fs/promises');
+//=> true
+
+isBuiltin('node:fs/promises');
+//=> true
+
+isBuiltin('unicorn');
+//=> false

--- a/test/fixtures/is-builtin-module/case-3/after.js
+++ b/test/fixtures/is-builtin-module/case-3/after.js
@@ -1,0 +1,15 @@
+var {
+  isBuiltin
+} = require("node:module");
+
+isBuiltin('fs');
+//=> true
+
+isBuiltin('fs/promises');
+//=> true
+
+isBuiltin('node:fs/promises');
+//=> true
+
+isBuiltin('unicorn');
+//=> false

--- a/test/fixtures/is-builtin-module/case-3/before.js
+++ b/test/fixtures/is-builtin-module/case-3/before.js
@@ -1,0 +1,13 @@
+var isModuleBuiltin = require('is-builtin-module');
+
+isModuleBuiltin('fs');
+//=> true
+
+isModuleBuiltin('fs/promises');
+//=> true
+
+isModuleBuiltin('node:fs/promises');
+//=> true
+
+isModuleBuiltin('unicorn');
+//=> false

--- a/test/fixtures/is-builtin-module/case-3/result.js
+++ b/test/fixtures/is-builtin-module/case-3/result.js
@@ -1,0 +1,15 @@
+var {
+  isBuiltin
+} = require("node:module");
+
+isBuiltin('fs');
+//=> true
+
+isBuiltin('fs/promises');
+//=> true
+
+isBuiltin('node:fs/promises');
+//=> true
+
+isBuiltin('unicorn');
+//=> false


### PR DESCRIPTION
This PR fixes two issues in the `is-builtin-module` codemod:

1. It doesn't work with non-standard import names. If you imported it like this:

    ```js
    import banana from 'is-builtin-module';
    ```

    The codemod would replace it with:

    ```js
    import { isBuiltin } from "node:module";
    ```

    But it wouldn't update the usages of the package, staying as `banana`. I've added a fixture under `case-2` to handle this.
1. It doesn't work with CJS. If used with a `require` call it would simply do nothing.

    I've added a fixture under `case-3` to test that.

Note: I'm facing an issue here, see my comment below 👇 