### PR TITLE
feat: add `object.hasown`

### DIFF
--- a/codemods/object.hasown/index.js
+++ b/codemods/object.hasown/index.js
@@ -1,0 +1,44 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'object.hasown',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			let dirtyFlag = false;
+
+			const { identifier } = removeImport('object.hasown', root, j);
+
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.value.arguments;
+					const newExpression = j.callExpression(
+						j.memberExpression(j.identifier('Object'), j.identifier('hasOwn')),
+						//@ts-ignore
+						args,
+					);
+					j(path).replaceWith(newExpression);
+					dirtyFlag = true;
+				});
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/test/fixtures/object.hasown/case-1/after.js
+++ b/test/fixtures/object.hasown/case-1/after.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.equal(Object.hasOwn({}, "toString"), false);
+assert.equal(Object.hasOwn([], "length"), true);
+assert.equal(Object.hasOwn({ a: 42 }, "a"), true);

--- a/test/fixtures/object.hasown/case-1/before.js
+++ b/test/fixtures/object.hasown/case-1/before.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+const hasOwn = require("object.hasown");
+
+assert.equal(hasOwn({}, "toString"), false);
+assert.equal(hasOwn([], "length"), true);
+assert.equal(hasOwn({ a: 42 }, "a"), true);

--- a/test/fixtures/object.hasown/case-1/result.js
+++ b/test/fixtures/object.hasown/case-1/result.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.equal(Object.hasOwn({}, "toString"), false);
+assert.equal(Object.hasOwn([], "length"), true);
+assert.equal(Object.hasOwn({ a: 42 }, "a"), true);


### PR DESCRIPTION
Basically the same as the existing `hasown` but from `es-shims`.

I wonder if there is existing infrastructure to avoid duplicating codemods like this?