### PR TITLE
feat: add codemods for `number.*` polyfills

### DIFF
--- a/codemods/number.isfinite/index.js
+++ b/codemods/number.isfinite/index.js
@@ -1,0 +1,28 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.isfinite',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport('number.isfinite', root, j);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/codemods/number.isinteger/index.js
+++ b/codemods/number.isinteger/index.js
@@ -1,0 +1,28 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.isinteger',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport('number.isinteger', root, j);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/codemods/number.issafeinteger/index.js
+++ b/codemods/number.issafeinteger/index.js
@@ -1,0 +1,28 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.issafeinteger',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport('number.issafeinteger', root, j);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/codemods/number.parsefloat/index.js
+++ b/codemods/number.parsefloat/index.js
@@ -1,0 +1,28 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.parsefloat',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport('number.parsefloat', root, j);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/codemods/number.parseint/index.js
+++ b/codemods/number.parseint/index.js
@@ -1,0 +1,28 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.parseint',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport('number.parseint', root, j);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/codemods/number.prototype.toexponential/index.js
+++ b/codemods/number.prototype.toexponential/index.js
@@ -1,0 +1,32 @@
+/**
+ * @import { Codemod, CodemodOptions } from "../../types.js"
+ */
+
+import jscodeshift from 'jscodeshift';
+
+import { removeImport } from '../shared.js';
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'number.prototype.toexponential',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const importDeclaration = removeImport(
+				'number.prototype.toexponential',
+				root,
+				j,
+			);
+
+			if (importDeclaration) {
+				return root.toSource({ quote: 'single' });
+			}
+
+			return file.source;
+		},
+	};
+}

--- a/test/fixtures/number.isfinite/case-1/after.js
+++ b/test/fixtures/number.isfinite/case-1/after.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isfinite/case-1/before.js
+++ b/test/fixtures/number.isfinite/case-1/before.js
@@ -1,3 +1,5 @@
+require("number.isfinite");
+
 const assert = require("assert");
 
 assert.ok(Number.isFinite(3)); // true

--- a/test/fixtures/number.isfinite/case-1/before.js
+++ b/test/fixtures/number.isfinite/case-1/before.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isfinite/case-1/result.js
+++ b/test/fixtures/number.isfinite/case-1/result.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isinteger/case-1/after.js
+++ b/test/fixtures/number.isinteger/case-1/after.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isinteger/case-1/after.js
+++ b/test/fixtures/number.isinteger/case-1/after.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
 
-assert.ok(Number.isFinite(3)); // true
-assert.notOk(Number.isFinite(Infinity)); // false
-assert.notOk(Number.isFinite("7")); // false
+assert.ok(Number.isInteger(3)); // true
+assert.notOk(Number.isInteger(Infinity)); // false
+assert.notOk(Number.isInteger("7")); // false

--- a/test/fixtures/number.isinteger/case-1/before.js
+++ b/test/fixtures/number.isinteger/case-1/before.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isinteger/case-1/before.js
+++ b/test/fixtures/number.isinteger/case-1/before.js
@@ -1,5 +1,7 @@
+require("number.isinteger");
+
 const assert = require("assert");
 
-assert.ok(Number.isFinite(3)); // true
-assert.notOk(Number.isFinite(Infinity)); // false
-assert.notOk(Number.isFinite("7")); // false
+assert.ok(Number.isInteger(3)); // true
+assert.notOk(Number.isInteger(Infinity)); // false
+assert.notOk(Number.isInteger("7")); // false

--- a/test/fixtures/number.isinteger/case-1/result.js
+++ b/test/fixtures/number.isinteger/case-1/result.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.ok(Number.isFinite(3)); // true
+assert.notOk(Number.isFinite(Infinity)); // false
+assert.notOk(Number.isFinite("7")); // false

--- a/test/fixtures/number.isinteger/case-1/result.js
+++ b/test/fixtures/number.isinteger/case-1/result.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
 
-assert.ok(Number.isFinite(3)); // true
-assert.notOk(Number.isFinite(Infinity)); // false
-assert.notOk(Number.isFinite("7")); // false
+assert.ok(Number.isInteger(3)); // true
+assert.notOk(Number.isInteger(Infinity)); // false
+assert.notOk(Number.isInteger("7")); // false

--- a/test/fixtures/number.issafeinteger/case-1/after.js
+++ b/test/fixtures/number.issafeinteger/case-1/after.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.ok(Number.isSafeInteger(-3)); // true
+assert.notOk(Number.isSafeInteger(2 ** 53)); // false
+assert.ok(Number.isSafeInteger(2 ** 53 - 1)); // true
+assert.notOk(Number.isSafeInteger("7")); // false

--- a/test/fixtures/number.issafeinteger/case-1/before.js
+++ b/test/fixtures/number.issafeinteger/case-1/before.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.ok(Number.isSafeInteger(-3)); // true
+assert.notOk(Number.isSafeInteger(2 ** 53)); // false
+assert.ok(Number.isSafeInteger(2 ** 53 - 1)); // true
+assert.notOk(Number.isSafeInteger("7")); // false

--- a/test/fixtures/number.issafeinteger/case-1/before.js
+++ b/test/fixtures/number.issafeinteger/case-1/before.js
@@ -1,3 +1,5 @@
+require("number.issafeinteger");
+
 const assert = require("assert");
 
 assert.ok(Number.isSafeInteger(-3)); // true

--- a/test/fixtures/number.issafeinteger/case-1/result.js
+++ b/test/fixtures/number.issafeinteger/case-1/result.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.ok(Number.isSafeInteger(-3)); // true
+assert.notOk(Number.isSafeInteger(2 ** 53)); // false
+assert.ok(Number.isSafeInteger(2 ** 53 - 1)); // true
+assert.notOk(Number.isSafeInteger("7")); // false

--- a/test/fixtures/number.parsefloat/case-1/after.js
+++ b/test/fixtures/number.parsefloat/case-1/after.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.equal(Number.parseFloat("-3"), -3); // -3
+assert.equal(Number.parseFloat("0.43"), 0.43); // 0.43
+assert.equal(Number.parseFloat("test"), Number.NaN); // NaN

--- a/test/fixtures/number.parsefloat/case-1/before.js
+++ b/test/fixtures/number.parsefloat/case-1/before.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.equal(Number.parseFloat("-3"), -3); // -3
+assert.equal(Number.parseFloat("0.43"), 0.43); // 0.43
+assert.equal(Number.parseFloat("test"), Number.NaN); // NaN

--- a/test/fixtures/number.parsefloat/case-1/before.js
+++ b/test/fixtures/number.parsefloat/case-1/before.js
@@ -1,3 +1,5 @@
+require("number.parsefloat");
+
 const assert = require("assert");
 
 assert.equal(Number.parseFloat("-3"), -3); // -3

--- a/test/fixtures/number.parsefloat/case-1/result.js
+++ b/test/fixtures/number.parsefloat/case-1/result.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+assert.equal(Number.parseFloat("-3"), -3); // -3
+assert.equal(Number.parseFloat("0.43"), 0.43); // 0.43
+assert.equal(Number.parseFloat("test"), Number.NaN); // NaN

--- a/test/fixtures/number.parseint/case-1/after.js
+++ b/test/fixtures/number.parseint/case-1/after.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal(Number.parseInt("-3"), -3); // -3
+assert.equal(Number.parseInt("0x10"), 16); // 16
+assert.equal(Number.parseInt("30", 7), 21); // 21
+assert.equal(Number.parseInt("ef"), Number.NaN); // NaN

--- a/test/fixtures/number.parseint/case-1/before.js
+++ b/test/fixtures/number.parseint/case-1/before.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal(Number.parseInt("-3"), -3); // -3
+assert.equal(Number.parseInt("0x10"), 16); // 16
+assert.equal(Number.parseInt("30", 7), 21); // 21
+assert.equal(Number.parseInt("ef"), Number.NaN); // NaN

--- a/test/fixtures/number.parseint/case-1/before.js
+++ b/test/fixtures/number.parseint/case-1/before.js
@@ -1,3 +1,5 @@
+require("number.parseint");
+
 const assert = require("assert");
 
 assert.equal(Number.parseInt("-3"), -3); // -3

--- a/test/fixtures/number.parseint/case-1/result.js
+++ b/test/fixtures/number.parseint/case-1/result.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal(Number.parseInt("-3"), -3); // -3
+assert.equal(Number.parseInt("0x10"), 16); // 16
+assert.equal(Number.parseInt("30", 7), 21); // 21
+assert.equal(Number.parseInt("ef"), Number.NaN); // NaN

--- a/test/fixtures/number.prototype.toexponential/case-1/after.js
+++ b/test/fixtures/number.prototype.toexponential/case-1/after.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal((-3).toExponential(), "-3e+0"); // "-3e+0"
+assert.equal((0x10).toExponential(2), "1.60e+1"); // "1.60e+1"
+assert.equal((1.23456).toExponential(5), "1.23456e+0"); // "1.23456e+0"
+assert.equal((-6.9e-11).toExponential(4), "-6.9000e-11"); // "-6.9000e-11"

--- a/test/fixtures/number.prototype.toexponential/case-1/before.js
+++ b/test/fixtures/number.prototype.toexponential/case-1/before.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal((-3).toExponential(), "-3e+0"); // "-3e+0"
+assert.equal((0x10).toExponential(2), "1.60e+1"); // "1.60e+1"
+assert.equal((1.23456).toExponential(5), "1.23456e+0"); // "1.23456e+0"
+assert.equal((-6.9e-11).toExponential(4), "-6.9000e-11"); // "-6.9000e-11"

--- a/test/fixtures/number.prototype.toexponential/case-1/before.js
+++ b/test/fixtures/number.prototype.toexponential/case-1/before.js
@@ -1,3 +1,5 @@
+require("number.prototype.toexponential");
+
 const assert = require("assert");
 
 assert.equal((-3).toExponential(), "-3e+0"); // "-3e+0"

--- a/test/fixtures/number.prototype.toexponential/case-1/result.js
+++ b/test/fixtures/number.prototype.toexponential/case-1/result.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+assert.equal((-3).toExponential(), "-3e+0"); // "-3e+0"
+assert.equal((0x10).toExponential(2), "1.60e+1"); // "1.60e+1"
+assert.equal((1.23456).toExponential(5), "1.23456e+0"); // "1.23456e+0"
+assert.equal((-6.9e-11).toExponential(4), "-6.9000e-11"); // "-6.9000e-11"


### PR DESCRIPTION
Nothing much to do with those polyfills packages. Except removing the possible imports.

Luckily they're not popular _(based on downloads)_.
